### PR TITLE
Error handling: log all fields in the error stack

### DIFF
--- a/src/application/jobs/split/splitter/file_splitter/local_splitter.go
+++ b/src/application/jobs/split/splitter/file_splitter/local_splitter.go
@@ -84,6 +84,7 @@ func (l LocalFileSplitter) runSpleeter(sourcePath string, destPath string, split
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		logger.Info(string(output))
 		return cerr.Field("spleeter_output", string(output)).
 			Wrap(err).Error("Error occurred while running spleeter")
 	}

--- a/src/application/worker/worker.go
+++ b/src/application/worker/worker.go
@@ -76,7 +76,7 @@ func (q *QueueWorker) Start() error {
 		logger.Info("Handling message")
 		err := q.handleMessage(message)
 		if err != nil {
-			err = cerr.Field("message_type", message.Body).
+			err = cerr.Field("message_type", message.Type).
 				Wrap(err).Error("Failed to process message")
 
 			cerr.Log(err)

--- a/src/lib/cerr/error.go
+++ b/src/lib/cerr/error.go
@@ -50,6 +50,10 @@ func (c ContextualError) Unwrap() error {
 	return c.Context.WrappedError
 }
 
+func (c ContextualError) Fields() map[string]interface{} {
+	return c.Context.ContextFields
+}
+
 func (c ContextualError) Error() string {
 	return c.String()
 }


### PR DESCRIPTION
The error logging method had neglected to collect all the errors in the wrapped stack - we need to unwrap the entire chain and aggregate all the error fields otherwise we'll only see the top error context.