### PR TITLE
Don't retry jobs for now

### DIFF
--- a/src/application/worker/worker.go
+++ b/src/application/worker/worker.go
@@ -81,7 +81,7 @@ func (q *QueueWorker) Start() error {
 
 			cerr.Log(err)
 
-			if err = message.Nack(false, true); err != nil {
+			if err = message.Nack(false, false); err != nil {
 				logger.Error("Failed to nack message")
 			}
 		} else {


### PR DESCRIPTION
Some jobs are unretriable, we need to find a way to discern. For now, don't keep repeating jobs that failed because it's a resource drain.