### PR TITLE
Update to use new spleeter syntax

### DIFF
--- a/src/application/integration_test/dummy/spleeter_executor.go
+++ b/src/application/integration_test/dummy/spleeter_executor.go
@@ -47,10 +47,9 @@ func (s SpleeterCommand) CombinedOutput() ([]byte, error) {
 		return nil, UnexpectedInput
 	}
 
-	sourcePath, err := getOptionValue(s.Args, "-i")
-	if err != nil {
-		return nil, err
-	}
+	lastIndex := len(s.Args) - 1
+
+	sourcePath := s.Args[lastIndex]
 
 	splitParam, err := getOptionValue(s.Args, "-p")
 	if err != nil {

--- a/src/application/integration_test/dummy/spleeter_executor.go
+++ b/src/application/integration_test/dummy/spleeter_executor.go
@@ -73,15 +73,15 @@ func (s SpleeterCommand) CombinedOutput() ([]byte, error) {
 	stems := []string{}
 
 	switch splitParam {
-	case "spleeter:2stems-16khz":
+	case "spleeter:2stems-16kHz":
 		{
 			stems = append(stems, "vocals", "accompaniment")
 		}
-	case "spleeter:4stems-16khz":
+	case "spleeter:4stems-16kHz":
 		{
 			stems = append(stems, "vocals", "other", "bass", "drums")
 		}
-	case "spleeter:5stems-16khz":
+	case "spleeter:5stems-16kHz":
 		{
 			stems = append(stems, "vocals", "other", "piano", "bass", "drums")
 		}

--- a/src/application/jobs/split/splitter/file_splitter/local_splitter.go
+++ b/src/application/jobs/split/splitter/file_splitter/local_splitter.go
@@ -16,9 +16,9 @@ import (
 var _ splitter.FileSplitter = LocalFileSplitter{}
 
 var paramMap = map[splitter.SplitType]string{
-	splitter.SplitTwoStemsType:  "spleeter:2stems-16khz",
-	splitter.SplitFourStemsType: "spleeter:4stems-16khz",
-	splitter.SplitFiveStemsType: "spleeter:5stems-16khz",
+	splitter.SplitTwoStemsType:  "spleeter:2stems-16kHz",
+	splitter.SplitFourStemsType: "spleeter:4stems-16kHz",
+	splitter.SplitFiveStemsType: "spleeter:5stems-16kHz",
 }
 
 func NewLocalFileSplitter(workingDirStr string, spleeterBinPath string, executor executor.Executor) (LocalFileSplitter, error) {

--- a/src/application/jobs/split/splitter/file_splitter/local_splitter.go
+++ b/src/application/jobs/split/splitter/file_splitter/local_splitter.go
@@ -80,7 +80,7 @@ func (l LocalFileSplitter) runSpleeter(sourcePath string, destPath string, split
 
 	logger.Info("Running spleeter command")
 
-	args := []string{"separate", "-i", sourcePath, "-p", splitParam, "-o", destPath, "-c", "mp3", "-b", "320k", "-f", "{instrument}.mp3"}
+	args := []string{"separate", "-p", splitParam, "-o", destPath, "-c", "mp3", "-b", "320k", "-f", "{instrument}.mp3", sourcePath}
 
 	errctx := cerr.Field("spleeter_bin_path", l.spleeterBinPath).Field("spleeter_args", args)
 


### PR DESCRIPTION
A couple key changes that the new spleeter command line wants:
-instead of `-i source`, it's now `... options source`
-instead of `khz` it's now `kHz`

real helpful