### PR TITLE
Make each pod a single threaded worker

### DIFF
--- a/.k8s/deploy.yml
+++ b/.k8s/deploy.yml
@@ -26,8 +26,6 @@ spec:
           value: /usr/local/bin/spleeter
         - name: SPLEETER_WORKING_DIR_PATH
           value: /spleeter-scratch
-        - name: NUM_WORKERS
-          value: "5"
         - name: YOUTUBEDL_BIN_PATH
           value: /shared/youtube-dl
         - name: YOUTUBEDL_WORKING_DIR_PATH

--- a/src/main.go
+++ b/src/main.go
@@ -6,10 +6,7 @@ import (
 
 func main() {
 	app := application.NewApp()
-	app.Start()
-	waitForever()
-}
-
-func waitForever() {
-	<-make(chan bool)
+	if err := app.Start(); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
To make each pod more predictable in resource usage, limit it to just 1 worker each. 2 threads running spleeter concurrently may blow up the RAM in a single pod.